### PR TITLE
Fix: Handle spaces in paths for move command in CSharpManager.csproj

### DIFF
--- a/CSharpManager/CSharpManager.csproj
+++ b/CSharpManager/CSharpManager.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="move /Y $(TargetPath) $(OutDir)CSharpManager.bin" />
+    <Exec Command='move /Y "$(TargetPath)" "$(OutDir)CSharpManager.bin"' />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
给CSharpManager.csproj的PostBuild脚本中的move命令加入引号，避免工程路径带有空格时执行move命令时报错